### PR TITLE
Add EEGauge to Python Toolboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ These applications help you design BCI experiments, run them, collect data, and 
 * [EEG-ExPy](https://github.com/neurotechx/eeg-expy)
 * [PyBCI](https://github.com/LMBooth/pybci)
 * [mw75-streamer](https://github.com/arctop/mw75-streamer)
+* [EEGauge](https://github.com/YG-paaleee/eegauge) - Audit public EEG/BCI datasets and reproduce simple baselines honestly (leakage-aware splits, chance/significance, per-class metrics, and MOABB + EEGDash metadata).
 
 ### Mobile Apps
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ These applications help you design BCI experiments, run them, collect data, and 
 * [EEG-ExPy](https://github.com/neurotechx/eeg-expy)
 * [PyBCI](https://github.com/LMBooth/pybci)
 * [mw75-streamer](https://github.com/arctop/mw75-streamer)
-* [EEGauge](https://github.com/YG-paaleee/eegauge) - Audit public EEG/BCI datasets and reproduce simple baselines honestly (leakage-aware splits, chance/significance, per-class metrics, and MOABB + EEGDash metadata).
+* [EEGauge](https://github.com/YG-paaleee/eegauge)
 
 ### Mobile Apps
 


### PR DESCRIPTION
Adds **EEGauge** to the Python Toolboxes section.

Disclosure: I'm the author. EEGauge is a small, MIT-licensed Python CLI that generates
plain-language "dataset cards" for public EEG/BCI datasets - it runs a simple CSP+LDA
baseline, reports chance level and an approximate significance test, shows per-class
metrics + a confusion matrix, and flags leakage risks (within- vs cross-subject). It
reads metadata from MOABB and from EEGDash (OpenNeuro/NEMAR), and is not medical software.

- Repo: https://github.com/YG-paaleee/eegauge
- Actively maintained (tagged releases, CI on Windows/Linux x Python 3.11/3.12, tests, docs).

I followed the format in CONTRIBUTING.md (`[Name](link) - description`); the existing
Python Toolboxes entries are bare links, so I'm happy to drop the description to match the
section if you'd prefer. Thanks for maintaining this list!
